### PR TITLE
New feature/view: users can now create a business and subsequently delete businesses

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,21 +17,24 @@
         android:theme="@style/Theme.AppCompat.Light.NoActionBar"
         tools:targetApi="31">
         <activity
+            android:name=".business_center.CreateBusinessActivity"
+            android:exported="false" />
+        <activity
             android:name=".search.SearchActivity"
             android:exported="false"
-            android:launchMode="singleTask"/>
+            android:launchMode="singleTask" />
         <activity
             android:name=".profile.ProfileActivity"
             android:exported="false"
-            android:launchMode="singleTask"/>
+            android:launchMode="singleTask" />
         <activity
             android:name=".map.MapActivity"
             android:exported="false"
-            android:launchMode="singleTask"/>
+            android:launchMode="singleTask" />
         <activity
             android:name=".home.HomeActivity"
             android:exported="false"
-            android:launchMode="singleTask"/>
+            android:launchMode="singleTask" />
         <activity
             android:name=".register.RegisterActivity"
             android:exported="false" />

--- a/app/src/main/java/com/papigelvez/a5palas12/business_center/CreateBusinessActivity.kt
+++ b/app/src/main/java/com/papigelvez/a5palas12/business_center/CreateBusinessActivity.kt
@@ -1,0 +1,199 @@
+package com.papigelvez.a5palas12.business_center
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.google.firebase.firestore.FirebaseFirestore
+import com.papigelvez.a5palas12.R
+import com.papigelvez.a5palas12.databinding.ActivityCreateBusinessBinding
+import com.papigelvez.a5palas12.databinding.ActivityProfileBinding
+import com.papigelvez.a5palas12.home.HomeActivity
+import com.papigelvez.a5palas12.login.LoginActivity
+import com.papigelvez.a5palas12.map.MapActivity
+import com.papigelvez.a5palas12.profile.ProfileActivity
+import com.papigelvez.a5palas12.search.SearchActivity
+
+class CreateBusinessActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityCreateBusinessBinding
+    private val firestore = FirebaseFirestore.getInstance()
+
+    private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
+
+    private val locationPermissionRequestCode = 1001
+
+    private lateinit var sharedPreferences: SharedPreferences
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
+
+        binding = ActivityCreateBusinessBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        sharedPreferences = getSharedPreferences("LoginCreds", Context.MODE_PRIVATE)
+
+        //revisar permisos
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                android.Manifest.permission.ACCESS_FINE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            //si no tiene, solicitar
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(android.Manifest.permission.ACCESS_FINE_LOCATION),
+                locationPermissionRequestCode
+            )
+        } else {
+            //ya se tienen los permisos
+            fetchCurrentLocation()
+        }
+
+        initUI()
+    }
+
+    private fun initUI() {
+        initListeners()
+    }
+
+    private fun initListeners() {
+        binding.linearColumnMaps.setOnClickListener {
+            val intent = Intent(this, MapActivity::class.java)
+            startActivity(intent)
+        }
+        binding.linearColumnSearch.setOnClickListener {
+            val intent = Intent(this, SearchActivity::class.java)
+            startActivity(intent)
+        }
+        binding.linearColumnHome.setOnClickListener {
+            val intent = Intent(this, HomeActivity::class.java)
+            startActivity(intent)
+        }
+        binding.btnSaveBusiness.setOnClickListener {
+            saveBusiness()
+        }
+    }
+
+    private fun saveBusiness() {
+        val businessName = binding.etBusinessName.text.toString().trim()
+        val businessLatitude = binding.etBusinessLatitude.text.toString().toDoubleOrNull()
+        val businessLongitude = binding.etBusinessLongitude.text.toString().toDoubleOrNull()
+        val businessPhoto = binding.etBusinessPhoto.text.toString().trim()
+        val businessCategories = binding.etBusinessCategories.text.toString().split(",").map { it.trim() }
+        val businessDescription = binding.etBusinessDescription.text.toString().trim()
+        val businessRating = binding.etBusinessRating.text.toString().toDoubleOrNull()
+        val businessAddress = binding.etBusinessAddress.text.toString().trim()
+
+        if (businessName.isEmpty() || businessLatitude == null || businessLongitude == null ||
+            businessPhoto.isEmpty() || businessCategories.isEmpty() || businessDescription.isEmpty() ||
+            businessRating == null || businessRating !in 1.0..5.0 || businessAddress.isEmpty()
+        ) {
+            Toast.makeText(this, "Please fill all fields correctly.", Toast.LENGTH_SHORT).show()
+        } else {
+            val documentRef = firestore.collection("restaurants").document()
+            val id = documentRef.id
+
+            val restaurantData = hashMapOf(
+                "id" to id,
+                "name" to businessName,
+                "latitude" to businessLatitude,
+                "longitude" to businessLongitude,
+                "photo" to businessPhoto,
+                "categories" to businessCategories,
+                "description" to businessDescription,
+                "rating" to businessRating,
+                "address" to businessAddress
+            )
+            firestore.collection("restaurants")
+                .add(restaurantData)
+                .addOnSuccessListener {
+                    Toast.makeText(this, "Restaurant added successfully!", Toast.LENGTH_SHORT).show()
+
+                    //agregar el nombre del restaurante como atributo del usuario
+                    val userEmail = sharedPreferences.getString("email", null)
+
+                    firestore.collection("users")
+                        .whereEqualTo("email", userEmail)
+                        .get()
+                        .addOnSuccessListener { userSnapshot ->
+                            if (!userSnapshot.isEmpty) {
+                                val userDocument = userSnapshot.documents.first()
+                                val userRef = userDocument.reference
+
+                                userRef.update("restaurant", businessName)
+                                    .addOnSuccessListener {
+                                        //agregar restaurante a sharedPreferences
+                                        sharedPreferences.edit().putString("userRestaurant", businessName).apply()
+                                    }
+                                    .addOnFailureListener { e ->
+                                        Toast.makeText(this, "Failed to update user: ${e.message}", Toast.LENGTH_SHORT).show()
+                                    }
+                            }
+                        }
+                        .addOnFailureListener { e ->
+                            Toast.makeText(this, "Failed to find user: ${e.message}", Toast.LENGTH_SHORT).show()
+                        }
+
+                    //cerrar actividad y redirigir a ProfileActivity
+                    val intent = Intent(this, ProfileActivity::class.java)
+                    startActivity(intent)
+                    finish()
+                }
+                .addOnFailureListener { e ->
+                    Toast.makeText(this, "Failed to add restaurant: ${e.message}", Toast.LENGTH_SHORT).show()
+                }
+        }
+    }
+
+    //manejar el resultado de la solicitud de permisos
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == locationPermissionRequestCode && grantResults.isNotEmpty() &&
+            grantResults[0] == PackageManager.PERMISSION_GRANTED
+        ) {
+            fetchCurrentLocation()
+        } else {
+            Toast.makeText(this, "Location permission is required.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    //obtener latitud y longitud del usuario
+    @SuppressLint("MissingPermission")
+    private fun fetchCurrentLocation() {
+        fusedLocationProviderClient.lastLocation
+            .addOnSuccessListener { location ->
+                if (location != null) {
+                    val latitude = location.latitude
+                    val longitude = location.longitude
+
+                    //colocar latitud y longitud en las dos casillas correspondientes del formulario
+                    binding.etBusinessLatitude.setText(latitude.toString())
+                    binding.etBusinessLongitude.setText(longitude.toString())
+                } else {
+                    Toast.makeText(this, "Unable to fetch location.", Toast.LENGTH_SHORT).show()
+                }
+            }
+            .addOnFailureListener { e ->
+                Toast.makeText(this, "Failed to get location: ${e.message}", Toast.LENGTH_SHORT).show()
+            }
+    }
+}

--- a/app/src/main/java/com/papigelvez/a5palas12/home/HomeActivity.kt
+++ b/app/src/main/java/com/papigelvez/a5palas12/home/HomeActivity.kt
@@ -1,12 +1,18 @@
 package com.papigelvez.a5palas12.home
 
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
+import android.content.SharedPreferences
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.firebase.Firebase
@@ -21,6 +27,10 @@ import com.papigelvez.a5palas12.map.MapActivity
 import com.papigelvez.a5palas12.profile.ProfileActivity
 import com.papigelvez.a5palas12.register.RegisterActivity
 import com.papigelvez.a5palas12.search.SearchActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 class HomeActivity : AppCompatActivity() {
 
@@ -28,6 +38,9 @@ class HomeActivity : AppCompatActivity() {
     private lateinit var binding: ActivityHomeBinding
     private lateinit var restaurantAdapter: HomeRestaurantAdapter
     private val viewModel: HomeViewModel by viewModels { HomeViewModelFactory(HomeModel(applicationContext), this) }
+    private lateinit var sharedPreferences: SharedPreferences
+    private val firestore = FirebaseFirestore.getInstance()
+    private lateinit var logoutReceiver: BroadcastReceiver
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -37,12 +50,28 @@ class HomeActivity : AppCompatActivity() {
 
         binding = ActivityHomeBinding.inflate(layoutInflater)
 
+        sharedPreferences = getSharedPreferences("LoginCreds", Context.MODE_PRIVATE)
+
         setContentView(binding.root)
 
         setupRecyclerView()
         observeViewModel()
 
+        fetchUserRestaurant()
+
         initUI()
+
+        //terminar la actividad si se hace logout
+        logoutReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                if (intent?.action == "LOGOUT_EVENT") {
+                    finish()
+                }
+            }
+        }
+
+        LocalBroadcastManager.getInstance(this)
+            .registerReceiver(logoutReceiver, IntentFilter("LOGOUT_EVENT"))
     }
 
     //binding del adapter
@@ -92,4 +121,40 @@ class HomeActivity : AppCompatActivity() {
         }
     }
 
+    private fun fetchUserRestaurant() {
+        CoroutineScope(Dispatchers.Main).launch {
+            //obtener el email del usuario loggeado
+            val email = sharedPreferences.getString("email", null)
+            if (email != null) {
+                try {
+                    //buscar documento de usuario que tenga ese email, snapshot pueden ser varios pero solo hay 1 por usuario
+                    val userSnapshot = firestore.collection("users")
+                        .whereEqualTo("email", email)
+                        .get()
+                        .await()
+
+                    //si se encontro el documento
+                    if (!userSnapshot.isEmpty) {
+                        val userDocument = userSnapshot.documents.first()
+                        val restaurant = userDocument.getString("restaurant") ?: ""
+
+                        //guardar restaurante en sharedpreferences
+                        sharedPreferences.edit()
+                            .putString("userRestaurant", restaurant)
+                            .apply()
+
+                    } else {
+                        Toast.makeText(this@HomeActivity, "No user found with this email.", Toast.LENGTH_SHORT).show()
+                    }
+                } catch (e: Exception) {
+                    Toast.makeText(this@HomeActivity, "Error fetching user data. Check your connection.", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(logoutReceiver)
+    }
 }

--- a/app/src/main/java/com/papigelvez/a5palas12/home/HomeActivity.kt
+++ b/app/src/main/java/com/papigelvez/a5palas12/home/HomeActivity.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 
 class HomeActivity : AppCompatActivity() {
 
@@ -122,32 +123,37 @@ class HomeActivity : AppCompatActivity() {
     }
 
     private fun fetchUserRestaurant() {
-        CoroutineScope(Dispatchers.Main).launch {
-            //obtener el email del usuario loggeado
+        CoroutineScope(Dispatchers.IO).launch {
+            // obtener el correo del usuario en sharedPreferences
             val email = sharedPreferences.getString("email", null)
             if (email != null) {
                 try {
-                    //buscar documento de usuario que tenga ese email, snapshot pueden ser varios pero solo hay 1 por usuario
+                    // obtener snapshot de firestore
                     val userSnapshot = firestore.collection("users")
                         .whereEqualTo("email", email)
                         .get()
                         .await()
 
-                    //si se encontro el documento
+                    // si se encuentra el documento, obtener valor de restaurante
                     if (!userSnapshot.isEmpty) {
                         val userDocument = userSnapshot.documents.first()
                         val restaurant = userDocument.getString("restaurant") ?: ""
 
-                        //guardar restaurante en sharedpreferences
+                        // guardar valor de restaurante en sharedPreferences
                         sharedPreferences.edit()
                             .putString("userRestaurant", restaurant)
                             .apply()
-
                     } else {
-                        Toast.makeText(this@HomeActivity, "No user found with this email.", Toast.LENGTH_SHORT).show()
+                        // mensajes Toast con el thread Main
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(this@HomeActivity, "No user found with this email.", Toast.LENGTH_SHORT).show()
+                        }
                     }
                 } catch (e: Exception) {
-                    Toast.makeText(this@HomeActivity, "Error fetching user data. Check your connection.", Toast.LENGTH_SHORT).show()
+                    // mensajes Toast con el thread Main
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(this@HomeActivity, "Error fetching user data. Check your connection.", Toast.LENGTH_SHORT).show()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/papigelvez/a5palas12/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/papigelvez/a5palas12/profile/ProfileActivity.kt
@@ -2,23 +2,39 @@ package com.papigelvez.a5palas12.profile
 
 import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Bundle
+import android.view.View
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
 import com.papigelvez.a5palas12.R
+import com.papigelvez.a5palas12.business_center.CreateBusinessActivity
 import com.papigelvez.a5palas12.databinding.ActivityProfileBinding
 import com.papigelvez.a5palas12.home.HomeActivity
 import com.papigelvez.a5palas12.login.LoginActivity
 import com.papigelvez.a5palas12.map.MapActivity
 import com.papigelvez.a5palas12.search.SearchActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 
 class ProfileActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityProfileBinding
 
-    private val sharedPreferences by lazy { getSharedPreferences("LoginCreds", Context.MODE_PRIVATE) }
+    private lateinit var sharedPreferences: SharedPreferences
+    private val firestore = FirebaseFirestore.getInstance()
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,6 +42,8 @@ class ProfileActivity : AppCompatActivity() {
         enableEdgeToEdge()
 
         binding = ActivityProfileBinding.inflate(layoutInflater)
+
+        sharedPreferences = getSharedPreferences("LoginCreds", Context.MODE_PRIVATE)
 
         setContentView(binding.root)
 
@@ -49,13 +67,141 @@ class ProfileActivity : AppCompatActivity() {
             val intent = Intent(this, HomeActivity::class.java)
             startActivity(intent)
         }
+        //quitar email de usuario de local storage y redirigir a login
         binding.linearRowLogout.setOnClickListener {
             val editor = sharedPreferences.edit()
             editor.remove("email")
-            editor.remove("password")
             editor.apply()
-            val intent = Intent(this, LoginActivity::class.java)
-            startActivity(intent)
+
+            val intent = Intent("LOGOUT_EVENT")
+            LocalBroadcastManager.getInstance(this).sendBroadcast(intent)
+
+            val loginIntent = Intent(this, LoginActivity::class.java)
+            loginIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(loginIntent)
+
+            finish()
         }
+        //si se presiona el boton businesscenter, desaparecer el menu de perfil y mostrar el de businesscenter
+        binding.linearRowBusinessCenter.setOnClickListener {
+            val userRestaurant = sharedPreferences.getString("userRestaurant", "")
+            if (userRestaurant.isNullOrEmpty()) {
+                binding.tvCreateBusiness.visibility = View.VISIBLE
+            } else {
+                binding.tvDeleteBusiness.visibility = View.VISIBLE
+            }
+            binding.linearUserprofile.visibility = View.GONE
+            binding.businessCenterMenu.visibility = View.VISIBLE
+        }
+        //si se presiona el boton de atras, desaparecer el menu de businesscenter y mostrar el de perfil
+        binding.backLayout.setOnClickListener {
+            binding.linearUserprofile.visibility = View.VISIBLE
+            binding.businessCenterMenu.visibility = View.GONE
+        }
+        //redirigir a la actividad de crear negocio
+        binding.tvCreateBusiness.setOnClickListener {
+            val intent = Intent(this, CreateBusinessActivity::class.java)
+            startActivity(intent)
+            finish()
+        }
+
+        binding.tvDeleteBusiness.setOnClickListener {
+            confirmDeletion()
+        }
+    }
+
+    private fun confirmDeletion() {
+        val userRestaurant = sharedPreferences.getString("userRestaurant", "")
+        AlertDialog.Builder(this)
+            .setTitle("Confirm Deletion")
+            .setMessage("Are you sure you wish to delete your restaurant '$userRestaurant'?")
+            .setPositiveButton("Yes") { _, _ ->
+                deleteRestaurant()
+            }
+            .setNegativeButton("No", null)
+            .show()
+    }
+
+    private fun deleteRestaurant() {
+        val userRestaurant = sharedPreferences.getString("userRestaurant", null)
+        val userEmail = sharedPreferences.getString("email", null)
+
+        if (userRestaurant.isNullOrEmpty() || userEmail.isNullOrEmpty()) {
+            Toast.makeText(this, "No restaurant found to delete.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        if (!isConnected()) {
+            Toast.makeText(this, "No internet connection. Please try again later.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        // Launch a coroutine on the I/O dispatcher for Firestore operations
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                // Delete the restaurant from "restaurants" collection
+                val querySnapshot = firestore.collection("restaurants")
+                    .whereEqualTo("name", userRestaurant)
+                    .get()
+                    .await()
+
+                if (!querySnapshot.isEmpty) {
+                    val restaurantDoc = querySnapshot.documents.first()
+                    restaurantDoc.reference.delete().await()
+
+                    // Delete the "restaurant" attribute from the user document
+                    deleteUserRestaurant(userEmail, userRestaurant)
+                } else {
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(this@ProfileActivity, "Restaurant not found in Firestore.", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(this@ProfileActivity, "Failed to delete restaurant: ${e.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    private suspend fun deleteUserRestaurant(email: String, restaurant: String) {
+        try {
+            val querySnapshot = firestore.collection("users")
+                .whereEqualTo("email", email)
+                .get()
+                .await()
+
+            if (!querySnapshot.isEmpty) {
+                val userDoc = querySnapshot.documents.first()
+                userDoc.reference.update("restaurant", FieldValue.delete()).await()
+
+                // eliminar el restaurante de sharedPreferences
+                withContext(Dispatchers.Main) {
+                    val editor = sharedPreferences.edit()
+                    editor.remove("userRestaurant")
+                    editor.apply()
+
+                    Toast.makeText(this@ProfileActivity, "Restaurant deleted successfully.", Toast.LENGTH_SHORT).show()
+                    binding.tvDeleteBusiness.visibility = View.GONE
+                    binding.tvCreateBusiness.visibility = View.VISIBLE
+                }
+
+            } else {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(this@ProfileActivity, "User document not found in Firestore.", Toast.LENGTH_SHORT).show()
+                }
+            }
+        } catch (e: Exception) {
+            withContext(Dispatchers.Main) {
+                Toast.makeText(this@ProfileActivity, "Failed to update user document: ${e.message}", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun isConnected(): Boolean {
+        val connectivityManager = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = connectivityManager.activeNetwork
+        val capabilities = connectivityManager.getNetworkCapabilities(network)
+        return capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
     }
 }

--- a/app/src/main/res/layout/activity_create_business.xml
+++ b/app/src/main/res/layout/activity_create_business.xml
@@ -1,0 +1,358 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".business_center.CreateBusinessActivity"
+    android:fitsSystemWindows="true">
+
+    <LinearLayout
+        android:id="@+id/linearColumn5palastwe"
+        style="@style/groupStylegray_700"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="@dimen/_111pxh"
+        android:paddingTop="@dimen/_21pxv"
+        android:paddingEnd="@dimen/_111pxh"
+        android:paddingBottom="@dimen/_21pxv"
+        app:layout_constraintTop_toTopOf="parent"
+        >
+
+        <TextView
+            android:id="@+id/txt5palastwelve"
+            style="@style/txtFascinateInlineregular30"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:ellipsize="end"
+            android:gravity="center_horizontal"
+            android:singleLine="true"
+            android:text="@string/lbl_5_pa_las_12" />
+    </LinearLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/frameBottombar"
+        app:layout_constraintTop_toBottomOf="@+id/linearColumn5palastwe"
+        android:fillViewport="true"
+        >
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:gravity="center"
+            style="@style/groupStylegray_300"
+            android:paddingEnd="@dimen/_11pxh"
+            android:paddingStart="@dimen/_11pxh">
+
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Create a Business"
+                android:gravity="center"
+                android:textSize="40sp"
+                style="@style/txtInterregular40"
+                />
+
+            <TextView android:ellipsize="end"
+                android:id="@+id/txtLogin"
+                android:layout_height="wrap_content"
+                android:layout_width="wrap_content"
+                android:singleLine="true"
+                android:textSize="18sp"
+                style="@style/txtInterregular11"
+                android:layout_marginTop="@dimen/_10pxv"
+                android:text="@string/msg_business_details"/>
+
+            <EditText
+                android:background="@drawable/rectangle_border_blue_gray_400_radius_8"
+                android:ellipsize="end"
+                android:hint="@string/lbl_enter_business_name"
+                android:id="@+id/etBusinessName"
+                android:inputType="text"
+                android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                android:paddingHorizontal="@dimen/_14pxh"
+                android:paddingVertical="@dimen/_14pxv"
+                android:singleLine="true"
+                android:textColorHint="@color/blue_gray_400"
+                style="@style/etRoundedOutline" tools:ignore="Autofill"/>
+
+            <EditText
+                android:background="@drawable/rectangle_border_blue_gray_400_radius_8"
+                android:ellipsize="end"
+                android:hint="@string/lbl_enter_business_latitude"
+                android:id="@+id/etBusinessLatitude"
+                android:inputType="numberDecimal|numberSigned"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_12pxv"
+                android:layout_width="match_parent"
+                android:paddingHorizontal="@dimen/_14pxh"
+                android:paddingVertical="@dimen/_14pxv"
+                android:singleLine="true"
+                android:textColorHint="@color/blue_gray_400"
+                style="@style/etRoundedOutline" tools:ignore="Autofill"/>
+
+            <EditText
+                android:background="@drawable/rectangle_border_blue_gray_400_radius_8"
+                android:ellipsize="end"
+                android:hint="@string/lbl_enter_business_longitude"
+                android:id="@+id/etBusinessLongitude"
+                android:inputType="numberDecimal|numberSigned"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_12pxv"
+                android:layout_width="match_parent"
+                android:paddingHorizontal="@dimen/_14pxh"
+                android:paddingVertical="@dimen/_14pxv"
+                android:singleLine="true"
+                android:textColorHint="@color/blue_gray_400"
+                style="@style/etRoundedOutline" tools:ignore="Autofill"/>
+
+            <EditText
+                android:background="@drawable/rectangle_border_blue_gray_400_radius_8"
+                android:drawablePadding="@dimen/_30pxh"
+                android:ellipsize="end"
+                android:hint="@string/lbl_enter_business_photo"
+                android:id="@+id/etBusinessPhoto"
+                android:inputType="textUri"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_12pxv"
+                android:layout_width="match_parent"
+                android:paddingBottom="@dimen/_14pxv"
+                android:paddingEnd="@dimen/_14pxh"
+                android:paddingStart="@dimen/_14pxh"
+                android:paddingTop="@dimen/_14pxv" android:singleLine="true"
+                android:textColorHint="@color/blue_gray_400"
+                style="@style/etRoundedOutline" tools:ignore="Autofill"/>
+
+            <EditText
+                android:background="@drawable/rectangle_border_blue_gray_400_radius_8"
+                android:drawablePadding="@dimen/_30pxh"
+                android:ellipsize="end"
+                android:hint="@string/lbl_enter_business_categories"
+                android:id="@+id/etBusinessCategories"
+                android:inputType="text"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_12pxv"
+                android:layout_width="match_parent"
+                android:paddingBottom="@dimen/_14pxv"
+                android:paddingEnd="@dimen/_14pxh"
+                android:paddingStart="@dimen/_14pxh"
+                android:paddingTop="@dimen/_14pxv" android:singleLine="true"
+                android:textColorHint="@color/blue_gray_400"
+                style="@style/etRoundedOutline" tools:ignore="Autofill"/>
+            <EditText
+                android:background="@drawable/rectangle_border_blue_gray_400_radius_8"
+                android:drawablePadding="@dimen/_30pxh"
+                android:ellipsize="end"
+                android:hint="@string/lbl_enter_business_description"
+                android:id="@+id/etBusinessDescription"
+                android:inputType="text"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_12pxv"
+                android:layout_width="match_parent"
+                android:paddingBottom="@dimen/_14pxv"
+                android:paddingEnd="@dimen/_14pxh"
+                android:paddingStart="@dimen/_14pxh"
+                android:paddingTop="@dimen/_14pxv" android:singleLine="true"
+                android:textColorHint="@color/blue_gray_400"
+                style="@style/etRoundedOutline" tools:ignore="Autofill"/>
+            <EditText
+                android:background="@drawable/rectangle_border_blue_gray_400_radius_8"
+                android:drawablePadding="@dimen/_30pxh"
+                android:ellipsize="end"
+                android:hint="@string/lbl_enter_business_rating"
+                android:id="@+id/etBusinessRating"
+                android:inputType="numberDecimal"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_12pxv"
+                android:layout_width="match_parent"
+                android:paddingBottom="@dimen/_14pxv"
+                android:paddingEnd="@dimen/_14pxh"
+                android:paddingStart="@dimen/_14pxh"
+                android:paddingTop="@dimen/_14pxv" android:singleLine="true"
+                android:textColorHint="@color/blue_gray_400"
+                style="@style/etRoundedOutline" tools:ignore="Autofill"/>
+            <EditText
+                android:background="@drawable/rectangle_border_blue_gray_400_radius_8"
+                android:drawablePadding="@dimen/_30pxh"
+                android:ellipsize="end"
+                android:hint="@string/lbl_enter_business_address"
+                android:id="@+id/etBusinessAddress"
+                android:inputType="text"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_12pxv"
+                android:layout_width="match_parent"
+                android:paddingBottom="@dimen/_14pxv"
+                android:paddingEnd="@dimen/_14pxh"
+                android:paddingStart="@dimen/_14pxh"
+                android:paddingTop="@dimen/_14pxv" android:singleLine="true"
+                android:textColorHint="@color/blue_gray_400"
+                style="@style/etRoundedOutline" tools:ignore="Autofill"/>
+            <Button
+                android:ellipsize="end" android:gravity="center"
+                android:id="@+id/btnSaveBusiness"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_40pxv"
+                android:layout_width="match_parent"
+                android:paddingBottom="@dimen/_13pxv"
+                android:paddingEnd="@dimen/_30pxh"
+                android:paddingStart="@dimen/_30pxh"
+                android:paddingTop="@dimen/_13pxv" android:singleLine="true"
+                android:text="@string/lbl_save_business"
+                android:textAllCaps="false" style="@style/btnSolidRounded"
+                />
+        </LinearLayout>
+
+    </ScrollView>
+
+    <FrameLayout
+        android:id="@+id/frameBottombar"
+        style="@style/groupStylegray_800cornerRadius"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <LinearLayout
+            android:id="@+id/linearRowhome"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="@dimen/_21pxv"
+            android:layout_marginBottom="@dimen/_21pxv"
+            android:baselineAligned="true"
+            android:orientation="horizontal">
+
+            <LinearLayout
+                android:id="@+id/linearColumnHome"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="@dimen/_8pxh"
+                android:paddingEnd="@dimen/_8pxh">
+
+                <ImageView
+                    android:id="@+id/imageHomeImage"
+                    android:layout_width="@dimen/_32pxh"
+                    android:layout_height="@dimen/_32pxh"
+                    android:layout_gravity="center"
+                    android:layout_marginTop="@dimen/_3pxv"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/img_icons8_home_100"
+                    tools:ignore="ContentDescription"
+                    tools:src="@drawable/img_icons8_home_100" />
+
+                <TextView
+                    android:id="@+id/txtHome"
+                    style="@style/txtInderregular10"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/_2pxh"
+                    android:layout_marginEnd="@dimen/_2pxh"
+                    android:ellipsize="end"
+                    android:gravity="center_horizontal"
+                    android:singleLine="true"
+                    android:text="@string/lbl_home" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/linearColumnSearch"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_2pxv"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <ImageView
+                    android:id="@+id/imageSearchImage"
+                    android:layout_width="@dimen/_32pxh"
+                    android:layout_height="@dimen/_32pxh"
+                    android:layout_gravity="center"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/img_icons8_search_100"
+                    tools:ignore="ContentDescription"
+                    tools:src="@drawable/img_icons8_search_100" />
+
+                <TextView
+                    android:id="@+id/txtSearch"
+                    style="@style/txtInterregular10"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:gravity="center_horizontal"
+                    android:singleLine="true"
+                    android:text="@string/lbl_search"/>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/linearColumnMaps"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_2pxv"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <ImageView
+                    android:id="@+id/imageMapsImage"
+                    android:layout_width="@dimen/_32pxh"
+                    android:layout_height="@dimen/_32pxh"
+                    android:layout_gravity="center"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/img_icons8_map_100_1"
+                    tools:ignore="ContentDescription"
+                    tools:src="@drawable/img_icons8_map_100_1" />
+
+                <TextView
+                    android:id="@+id/txtMaps"
+                    style="@style/txtInterregular10"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/_2pxh"
+                    android:layout_marginEnd="@dimen/_2pxh"
+                    android:ellipsize="end"
+                    android:gravity="center_horizontal"
+                    android:singleLine="true"
+                    android:text="@string/lbl_maps" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/linearColumnProfile"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/_2pxv"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                style="@style/groupStylegray_600cornerRadius"
+                >
+
+                <ImageView
+                    android:id="@+id/imageProfileImage"
+                    android:layout_width="@dimen/_32pxh"
+                    android:layout_height="@dimen/_32pxh"
+                    android:layout_gravity="center"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/img_icons8_user_100"
+                    tools:ignore="ContentDescription"
+                    tools:src="@drawable/img_icons8_user_100" />
+
+                <TextView
+                    android:id="@+id/txtProfile"
+                    style="@style/txtInterregular10"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/_2pxh"
+                    android:layout_marginEnd="@dimen/_2pxh"
+                    android:ellipsize="end"
+                    android:gravity="center_horizontal"
+                    android:singleLine="true"
+                    android:text="@string/lbl_profile" />
+            </LinearLayout>
+        </LinearLayout>
+    </FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -76,7 +76,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_marginTop="@dimen/_12pxv"
-                android:text="@string/msg_user_name_usere" />
+                tools:text="@string/msg_user_name_usere" />
 
             <View
                 android:id="@+id/lineLinetwoOne"
@@ -123,13 +123,15 @@
             </LinearLayout>
 
             <LinearLayout
-                android:id="@+id/linearRowlocationone"
+                android:id="@+id/linearRowBusinessCenter"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_marginTop="@dimen/_45pxv"
                 android:gravity="center_vertical"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:clickable="true"
+                android:focusable="true">
 
                 <TextView
                     android:id="@+id/txtBusinessCenter"
@@ -261,6 +263,95 @@
 
     </ScrollView>
 
+
+    <LinearLayout
+        android:id="@+id/businessCenterMenu"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/frameBottombar"
+        app:layout_constraintTop_toBottomOf="@+id/linearColumn5palastwe"
+        android:orientation="vertical"
+        android:visibility="gone"
+        >
+        <LinearLayout
+            android:id="@+id/backLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="start"
+            android:orientation="horizontal"
+            android:clickable="true"
+            android:focusable="true"
+            android:layout_marginTop="@dimen/_15pxv">
+
+            <ImageView
+                android:id="@+id/imageLeftArrow"
+                android:layout_width="@dimen/_22pxh"
+                android:layout_height="@dimen/_22pxh"
+                android:layout_gravity="top"
+                android:layout_marginStart="@dimen/_31pxh"
+                android:scaleType="fitXY"
+                android:rotation="180"
+                android:src="@drawable/img_right_arrow_1"
+                tools:ignore="ContentDescription"
+                tools:src="@drawable/img_right_arrow_1" />
+
+            <TextView
+                android:id="@+id/txtBack"
+                style="@style/txtFamiljenGroteskbold16"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/_15pxh"
+                android:layout_marginTop="@dimen/_2pxv"
+                android:ellipsize="end"
+                android:gravity="bottom"
+                android:singleLine="true"
+                android:text="@string/lbl_back" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/lbl_welcome_to_business_center"
+            style="@style/txtFascinateInlineregular30"
+            android:gravity="center_horizontal"
+            android:textColor="@color/black"
+            android:lines="2"
+            android:singleLine="false"
+            android:minLines="2"
+            android:layout_marginTop="@dimen/_15pxv"
+            />
+
+        <TextView
+            android:id="@+id/tvCreateBusiness"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:text="@string/lbl_create_a_business"
+            android:paddingStart="@dimen/_30pxv"
+            android:layout_marginTop="@dimen/_30pxv"
+            android:textSize="@dimen/_20pxh"
+            android:fontFamily="@font/fascinate_inline"
+            android:textFontWeight="900"
+            android:layout_marginStart="@dimen/_30pxv"
+            android:clickable="true"
+            android:visibility="gone"
+            />
+        <TextView
+            android:id="@+id/tvDeleteBusiness"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:text="@string/lbl_delete_business"
+            android:paddingStart="@dimen/_30pxv"
+            android:layout_marginTop="@dimen/_30pxv"
+            android:textSize="@dimen/_20pxh"
+            android:fontFamily="@font/fascinate_inline"
+            android:textFontWeight="900"
+            android:layout_marginStart="@dimen/_30pxv"
+            android:clickable="true"
+            android:visibility="gone"
+            />
+    </LinearLayout>
 
     <FrameLayout
         android:id="@+id/frameBottombar"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,4 +148,5 @@ At </string>
     <string name="lbl_international">International</string>
     <string name="lbl_buffet">Buffet</string>
     <string name="lbl_vegan">Vegan</string>
+    <string name="lbl_delete_business">Delete Business</string>
 </resources>


### PR DESCRIPTION
This PR includes a new feature/view for Android users: In Business Center, they can now create a business (or delete it if it was previously created).

This new feature entails a variety of functionalities:

- When the user logs in, a coroutine launches that retrieves the restaurant they have created from Firestore collection, if they haven't created a business yet, the value is an empty string. The value is saved inside Shared Preferences.
- If a user registers successfully, their data is not only saved in Firebase auth service, but also inside a "users" collection from Firestore.
- When they enter Business Center, the value of the restaurant they may or may not have created is looked up within Shared Preferences. Depending on the result, they can either create one or delete it.
- If they decide to delete it, it is deleted using an IO thread to not block the main thread: the Shared Preference is deleted, the user's attribute "restaurant" is deleted, and the entire restaurant document is deleted.
 