### PR TITLE
Caching strategy with an additional local-storage strategy

### DIFF
--- a/app/src/main/java/com/papigelvez/a5palas12/map/MapModel.kt
+++ b/app/src/main/java/com/papigelvez/a5palas12/map/MapModel.kt
@@ -3,6 +3,7 @@ package com.papigelvez.a5palas12.map
 import android.content.ContentValues.TAG
 import android.location.Location
 import android.util.Log
+import android.util.LruCache
 import android.widget.Toast
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
@@ -12,8 +13,21 @@ import com.papigelvez.a5palas12.entities.RestaurantEntity
 
 class MapModel {
 
+    private val cache: LruCache<String, List<RestaurantEntity>> = LruCache(1)
+
     //obtener restaurantes de firestore
     fun fetchNearbyRestaurants(userLocation: Location, onSuccess: (List<RestaurantEntity>) -> Unit, onFailure: (String) -> Unit) {
+
+        //la llave es la ubicacion del usuario, el valor es la lista de aquellos rests 10km a la redonda
+        val cacheKey = "${userLocation.latitude}_${userLocation.longitude}_10km"
+        val cachedRestaurants = getCachedNearbyRestaurants(cacheKey)
+
+        if (cachedRestaurants != null) {
+            Log.d(TAG, "Loaded restaurants from cache")
+            onSuccess(cachedRestaurants)
+            return
+        }
+
         val db = Firebase.firestore
         val restaurantsCollection = db.collection("restaurants")
 
@@ -46,11 +60,27 @@ class MapModel {
                     //    RestaurantEntity(name, address, description, latitude, longitude, rating, photo, categories)
                     //} else null
                 }
+                //cachear los restaurantes a 10km a la redonda
+                saveNearbyRestaurants(cacheKey, restaurants)
+                Log.d(TAG, "Loaded restaurants to cache")
                 onSuccess(restaurants)
             }
             .addOnFailureListener { exception ->
                 Log.d(TAG, "Error getting restaurant documents: ", exception)
                 onFailure(exception.message ?: "No se encontro la coleccion de restaurantes")
             }
+    }
+
+    fun clearCache() {
+        cache.evictAll()
+    }
+
+    fun saveNearbyRestaurants(key: String, restaurants: List<RestaurantEntity>) {
+        cache.put(key, restaurants)
+    }
+
+    //obtener la lista de restaurantes del cache
+    fun getCachedNearbyRestaurants(key: String): List<RestaurantEntity>? {
+        return cache.get(key)
     }
 }

--- a/app/src/main/java/com/papigelvez/a5palas12/map/MapViewModel.kt
+++ b/app/src/main/java/com/papigelvez/a5palas12/map/MapViewModel.kt
@@ -61,5 +61,8 @@ class MapViewModel : ViewModel() {
         }
     }
 
+    fun clearCache() {
+        mapModel.clearCache()
+    }
 }
 


### PR DESCRIPTION
This PR includes the implementation of a caching strategy: the restaurants within 10km from the user are cached using LruCache and so the time the MapActivity is resumed, there is no need to fetch data from firestore but only look up inside the cache. Additionally, the user's last location is saved in SharedPreferences so if the MapActivity is resumed but the user has moved at least 5km from the last location, the cache is cleared and data is fetched again.